### PR TITLE
implement removeById method to delete a task by ID, update related tests and swaps void to boolean from baseDAO.

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -72,7 +72,12 @@ POST http://localhost:8080/graphql
         })\n
     }"
 }
+###
+GRAPHQL http://localhost:8080/graphql
 
+mutation {
+  deleteById(id: 14)
+}
 ###
 ```
 3. Useful end-points:

--- a/src/main/java/br/com/pedr0limpio/resources/TaskResource.java
+++ b/src/main/java/br/com/pedr0limpio/resources/TaskResource.java
@@ -64,9 +64,14 @@ public Task searchById(int id) {
 
     @Mutation
     @Transactional
-    public void deleteById(int id) { //TODO[#5]: Implement the deleteById(int id) method to delete a task.
+    public String deleteById(int id) {
         try {
+            Task existing = taskBaseDAO.getById(id);
+            if (existing == null) {
+                return "task id " + id + " not found";
+            }
             taskBaseDAO.removeById(id);
+            return "task id " + id + " deleted";
         } catch (Exception e) {
             LOG.error("Error deleting task", e);
             throw new RuntimeException("Error deleting task", e);

--- a/src/main/java/br/com/pedr0limpio/services/MySQLDAO.java
+++ b/src/main/java/br/com/pedr0limpio/services/MySQLDAO.java
@@ -182,8 +182,29 @@ public Task getById(int id) { //Implement getById to fetch in DB for a task.
     }
 
     @Override
-    public void removeById(int id) { //TODO[#12]: Implement removeById(int id) to delete a task by id in DB.
-
+    public boolean removeById(int id) {
+        String deleteTaskTagsSql = "DELETE FROM TASK_TAGS WHERE task_id = ?";
+        String deleteTaskSql = "DELETE FROM TASKS WHERE task_id = ?";
+        int affectedRows = 0;
+        try (Connection conn = DriverManager.getConnection(url, username, password)) {
+            conn.setAutoCommit(false);
+            try (PreparedStatement stmt1 = conn.prepareStatement(deleteTaskTagsSql)) {
+                stmt1.setInt(1, id);
+                stmt1.executeUpdate();
+            }
+            try (PreparedStatement stmt2 = conn.prepareStatement(deleteTaskSql)) {
+                stmt2.setInt(1, id);
+                affectedRows = stmt2.executeUpdate();
+            }
+            conn.commit();
+        } catch (SQLException e) {
+            LOGGER.error(e.getMessage());
+            try (Connection conn = DriverManager.getConnection(url, username, password)) {
+                conn.rollback();
+            } catch (SQLException rollbackException) {
+                LOGGER.error(rollbackException.getMessage());
+            }
+        }
+        return affectedRows > 0;
     }
 }
-

--- a/src/main/java/br/com/pedr0limpio/services/TaskBaseDAO.java
+++ b/src/main/java/br/com/pedr0limpio/services/TaskBaseDAO.java
@@ -9,6 +9,6 @@ public abstract class TaskBaseDAO {
     public abstract List<Task> getAllTasks();
     public abstract Task getById(int id);
     public abstract void update(int idFrom, Task taskFor);
-    public abstract void removeById(int id);
+    public abstract boolean removeById(int id);
 }
 


### PR DESCRIPTION
- Added implementation for deleteById in TaskResource and MySQLDAO to allow deleting tasks by ID.
- deleteById now returns a user-friendly message indicating if the task was deleted or not found.
- Updated MySQLDAO.removeById to return a boolean indicating if a task was actually deleted.
- Added and fixed unit tests in TaskResourceTest to cover successful deletion, not found, and exception scenarios.
- Ensured structural austerity for said changes as Maintainability is enshrined as a first principle, thus being ultimate junior-friendly, for added quality predicate stewardship.
- Closes #5 