### PR TITLE
Implement update method in MySQLDAO and editById in TaskResource to update tasks in the database

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -78,6 +78,26 @@ GRAPHQL http://localhost:8080/graphql
 mutation {
   deleteById(id: 14)
 }
+
+###
+GRAPHQL http://localhost:8080/graphql
+
+mutation {
+    editById(id: 2, updatedTask: {
+        description: "Updated Task",
+        priority: Low,
+        tagList: [Personal],
+        creation: "2025-06-27T16:20:30.1Z",
+        conclusion: null
+    }) {
+    description
+    priority
+    tagList
+    creation
+    conclusion
+    }
+}
+
 ###
 ```
 3. Useful end-points:

--- a/src/main/java/br/com/pedr0limpio/resources/TaskResource.java
+++ b/src/main/java/br/com/pedr0limpio/resources/TaskResource.java
@@ -39,26 +39,26 @@ public class TaskResource {
         return taskBaseDAO.getAllTasks();
     }
 
-@Query
-@Description("Fetch a task by id")
-public Task searchById(int id) {
-    try {
-        return taskBaseDAO.getById(id);
-    } catch (Exception e) {
-        LOG.error("Error fetching task by id", e);
-        throw new RuntimeException("Error fetching task by id", e);
+    @Query
+    @Description("Fetch a task by id")
+    public Task searchById(int id) {
+        try {
+            return taskBaseDAO.getById(id);
+        } catch (Exception e) {
+            LOG.error("Error fetching task by id", e);
+            throw new RuntimeException("Error fetching task by id", e);
+        }
     }
-}
 
     @Mutation
     @Transactional
-    public Task editById(int id, Task taskFor) { //TODO[#4]: Implement the editById(int id, Task taskFor) method to update a task
+    public Task editById(int id, Task updatedTask) {
         try {
-            taskBaseDAO.update(id, taskFor);
-            return taskFor;
+            taskBaseDAO.update(id, updatedTask);
+            return updatedTask;
         } catch (Exception e) {
-            LOG.error("Error editing task", e);
-            throw new RuntimeException("Error editing task", e);
+            LOG.error("Error updating task with id " + id, e);
+            throw new RuntimeException("Could not update task", e);
         }
     }
 


### PR DESCRIPTION
- Implemented the editById(int id, Task task) method to update tasks by ID. 
- Added full update logic in MySQLDAO including updating main fields and tags, with transaction handling and rollback on failure.
- Implemented getById(int id) in MySQLDAO to fetch a task and its tags from the database.
- Added/updated unit tests in TaskResourceTest to cover:
- - Creating a new task.
- - Fetching by ID (success, not found, and exception cases).
- - Editing a task by ID and verifying DAO interaction.
- - Improved error handling and logging for database operations.
- Ensured all new and existing tests pass.
- Closes #4.
- Builds and passes tests.
- Updates database via insomnia.