### PR TITLE
18-add-an-action-to-qodana-code-check

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,0 +1,46 @@
+name: Qodana
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  qodana-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Docker Buildx
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      # Run Qodana analysis inside Docker and save CLI output to a log file
+      - name: Run Qodana via Docker
+        run: |
+          mkdir -p ${{ github.workspace }}/qodana-results
+          docker run --rm \
+            -v ${{ github.workspace }}:/data \
+            -v ${{ github.workspace }}/qodana-results:/data/results \
+            -w /data \
+            jetbrains/qodana-jvm-community:2024.1 | tee ${{ github.workspace }}/qodana-results/qodana.log
+
+      # Upload the Qodana results as a workflow artifact for download
+      - name: Upload Qodana Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: Qodana Report
+          path: ${{ github.workspace }}/qodana-results
+
+      # Remove previous Qodana Report Info steps and add a new concise summary
+      - name: Qodana Summary
+        if: always()
+        run: |
+          echo "### Qodana - Run Status" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Qodana analysis has completed. For detailed results and findings, please download the Qodana report artifact from the Artifacts section below." >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Qodana](https://github.com/pedr0limpio/tasky/actions/workflows/qodana.yml/badge.svg)](https://github.com/pedr0limpio/tasky/actions/workflows/qodana.yml)
 ![build badge](https://github.com/pedr0limpio/tasky/actions/workflows/maven.yml/badge.svg?event=push&branch=main)
 # Tasky - a simple todo tool
 

--- a/src/main/java/br/com/pedr0limpio/resources/TaskResource.java
+++ b/src/main/java/br/com/pedr0limpio/resources/TaskResource.java
@@ -52,6 +52,8 @@ public Task searchById(int id) {
     @Mutation
     @Transactional
     public Task editById(int id, Task taskFor) { //TODO[#4]: Implement the editById(int id, Task taskFor) method to update a task
+        // Intentional unused variable for Qodana test
+        String unusedQodanaTest = "This variable is not used";
         try {
             taskBaseDAO.update(id, taskFor);
             return taskFor;


### PR DESCRIPTION
- Updated .github/workflows/qodana.yml to use the Community linter.
- No longer requires the QODANA_TOKEN secret for workflow execution.
- Closes #18 