### PR TITLE
newTask return now task id created in db

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -44,54 +44,33 @@ FOREIGN KEY (tag_id) REFERENCES TAGS(tag_id)
 2. I use graphql-api.http (HTTP Client plugin build-in for IntelliJ) for dev testing of API;
    - Content of graphql-api.http:
 ```http request
-GRAPHQL http://localhost:8080/graphql
-    
-query {
-    sayHello(name: "Pedro")
-}
-
-###
-POST http://localhost:8080/graphql
-
-{
-    "query": "query($name: String!) {
-        sayHello(name: $name)
-    }",
-    "variables": {
-        "name": "Alice"
-    }
-}
-
-###
-POST http://localhost:8080/graphql
-
-{
-    "query": "{
-        sayHello(name: \"Pedro\") {
-        name,
-        surname
-        }
-    }"
-}
-
 ###
 GRAPHQL http://localhost:8080/graphql
 
 mutation {
     newTask(task: {
-    description: "test project",
-    priority: Info,
-    tagList: [Personal, Game],
-    creation: "2025-02-02T17:02:01Z",
-    conclusion: null
-}) {
-    id
-    description
-    priority
-    tagList
-    creation
-    conclusion
-    }
+        description: "Project Unknow New",
+        priority: High,
+        tagList: [Work],
+        creation: "2025-04-14T11:04:30.1Z",
+        conclusion: null
+    })
+}
+
+###
+POST http://localhost:8080/graphql
+
+{
+"query":
+    "mutation {\n
+        newTask(task: {\n
+            description: \"Project Unknow New\",\n
+            priority: High,\n
+            tagList: [Work],\n
+            creation: \"2025-04-14T11:04:30.1Z\",\n
+            conclusion: null\n
+        })\n
+    }"
 }
 
 ###

--- a/src/main/java/br/com/pedr0limpio/resources/TaskResource.java
+++ b/src/main/java/br/com/pedr0limpio/resources/TaskResource.java
@@ -23,14 +23,15 @@ public class TaskResource {
     @Mutation
     @Transactional
     @Description("Create a new task")
-    public Task newTask(Task task) {
+    public int newTask(Task task) {
+        int id = -1;
         try {
-            taskBaseDAO.writeTask(task);
-            return task;
+            id = taskBaseDAO.writeTask(task);
         } catch (Exception e) {
             LOG.error("Error creating new task", e);
             throw new RuntimeException("Error creating new task", e);
         }
+        return id;
     }
 
     @Query

--- a/src/main/java/br/com/pedr0limpio/services/MySQLDAO.java
+++ b/src/main/java/br/com/pedr0limpio/services/MySQLDAO.java
@@ -41,11 +41,11 @@ public class MySQLDAO extends TaskBaseDAO {
     }
 
     @Override
-    public void writeTask(Task task) {
+    public int writeTask(Task task) {
+        int taskId = -1;
         try (Connection conn = DriverManager.getConnection(url, username, password)) {
             conn.setAutoCommit(false);
-
-            int taskId = insertTask(conn, task);
+            taskId = insertTask(conn, task);
             if (taskId == -1) {
                 throw new SQLException("Failed to write task.");
             }
@@ -55,10 +55,8 @@ public class MySQLDAO extends TaskBaseDAO {
                 if (tagId == -1) {
                     throw new SQLException("Failed to insert and/or get tag ID for tag: " + tag);
                 }
-
                 insertTaskTag(conn, taskId, tagId);
             }
-
             conn.commit();
         } catch (SQLException e) {
             LOGGER.error(e.getMessage());
@@ -68,6 +66,7 @@ public class MySQLDAO extends TaskBaseDAO {
                 LOGGER.error(rollbackException.getMessage());
             }
         }
+        return taskId;
     }
 
     private int insertTask(Connection conn, Task task) throws SQLException {

--- a/src/main/java/br/com/pedr0limpio/services/TaskBaseDAO.java
+++ b/src/main/java/br/com/pedr0limpio/services/TaskBaseDAO.java
@@ -5,7 +5,7 @@ import br.com.pedr0limpio.models.Task;
 import java.util.List;
 
 public abstract class TaskBaseDAO {
-    public abstract void writeTask(Task task);
+    public abstract int writeTask(Task task);
     public abstract List<Task> getAllTasks();
     public abstract Task getById(int id);
     public abstract void update(int idFrom, Task taskFor);

--- a/src/test/java/br/com/pedr0limpio/resources/TaskResourceTest.java
+++ b/src/test/java/br/com/pedr0limpio/resources/TaskResourceTest.java
@@ -29,15 +29,8 @@ public class TaskResourceTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        Task mockTask = new Task();
-        mockTask.setDescription("create a new task");
-        mockTask.setPriority(Priority.Medium);
-        mockTask.setTagList(Arrays.asList(Tag.Work, Tag.Fun));
-        mockTask.setCreation(new Date());
-        mockTask.setConclusion(null);
-
-        doNothing().when(taskBaseDAO).writeTask(any(Task.class));
-        when(taskBaseDAO.getById(1)).thenReturn(mockTask);
+        when(taskBaseDAO.writeTask(any(Task.class))).thenReturn(1);
+        when(taskBaseDAO.getById(1)).thenReturn(new Task());
     }
 
     @Test
@@ -48,21 +41,21 @@ public class TaskResourceTest {
         newTask.setTagList(Arrays.asList(Tag.Work, Tag.Fun));
         newTask.setCreation(new Date());
         newTask.setConclusion(null);
-
+        when(taskBaseDAO.writeTask(any(Task.class))).thenReturn(1);
         taskResource.newTask(newTask);
         verify(taskBaseDAO).writeTask(any(Task.class));
     }
 
     @Test
     public void testGetById() {
-        Task mockTask = mock(Task.class);
-        when(mockTask.getDescription()).thenReturn("create a new task");
-        when(mockTask.getPriority()).thenReturn(Priority.Medium);
-        when(mockTask.getTagList()).thenReturn(Arrays.asList(Tag.Work, Tag.Fun));
+        Task mockTask = new Task();
+        mockTask.setDescription("create a new task");
+        mockTask.setPriority(Priority.Medium);
+        mockTask.setTagList(Arrays.asList(Tag.Work, Tag.Fun));
+        mockTask.setCreation(new Date());
+        mockTask.setConclusion(null);
         when(taskBaseDAO.getById(1)).thenReturn(mockTask);
-
         Task task = taskResource.searchById(1);
-
         assertEquals("create a new task", task.getDescription());
         assertEquals(Priority.Medium, task.getPriority());
         assertEquals(Arrays.asList(Tag.Work, Tag.Fun), task.getTagList());


### PR DESCRIPTION
 CHANGED: writeTask() now returns int instead of void

The method signature was updated:

  - public abstract void writeTask(Task task);
  + public abstract int writeTask(Task task);

All  writeTask() repercussions must now return an int. Adjust accordingly.